### PR TITLE
On boot-up, delete schedules before creating from hash

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,6 @@
 Sidekiq.configure_server do |config|
+  Sidekiq::Cron::Job.destroy_all!
+
   schedule_file = Rails.root.join("config", "schedule.yml")
 
   if File.exists?(schedule_file)


### PR DESCRIPTION
This removes old schedules (that are not overwritten).