### PR TITLE
Destroy ward destroys its reports, and then reports destroy its responses

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,7 +3,7 @@ class Report < ActiveRecord::Base
   belongs_to :operation
   belongs_to :ward
 
-  has_many :report_responses
+  has_many :report_responses, dependent: :destroy
 
   enum status: {
     error: -1,

--- a/app/models/ward.rb
+++ b/app/models/ward.rb
@@ -1,5 +1,7 @@
 class Ward < ActiveRecord::Base
 
+  has_many :reports, dependent: :destroy
+
   scope :watching, ->(operation) do
     addresses = Operation::ADDRESS_FIELDS.map do |field|
       operation.body[field.to_s]

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Report do
   describe "assocations" do
     it { is_expected.to belong_to(:operation) }
     it { is_expected.to belong_to(:ward) }
-    it { is_expected.to have_many(:report_responses) }
+    it { is_expected.to have_many(:report_responses).dependent(:destroy) }
   end
 
 end

--- a/spec/models/ward_spec.rb
+++ b/spec/models/ward_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Ward do
 
+  describe "associations" do
+    it { is_expected.to have_many(:reports).dependent(:destroy) }
+  end
+
   describe ".watching" do
     let!(:ward) do
       create(:ward, {


### PR DESCRIPTION
Prepare for deleting wards that consistently error out