### PR TITLE
Enqueue models after they have been committed into the database

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "faraday-detailed_logger", "~> 2.1"
 gem "apipie-rails", "0.3.6"
 gem "maruku", "0.7.2"
 gem "lograge", "0.4.1"
+gem "ar_after_transaction", "0.4.0"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -70,6 +71,7 @@ group :test do
   gem "timecop", "0.8.0"
   gem "vcr", "~> 3.0"
   gem "webmock", "~> 2.3"
+  gem "database_cleaner"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     apipie-rails (0.3.6)
       json
+    ar_after_transaction (0.4.0)
+      activerecord
     arel (7.1.4)
     builder (3.2.3)
     byebug (9.0.6)
@@ -63,6 +65,7 @@ GEM
     connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     diff-lcs (1.3)
     dotenv (2.1.2)
@@ -274,8 +277,10 @@ PLATFORMS
 
 DEPENDENCIES
   apipie-rails (= 0.3.6)
+  ar_after_transaction (= 0.4.0)
   capybara (~> 2.4)
   coffee-rails (~> 4.2)
+  database_cleaner
   dotenv-rails (~> 2.1)
   factory_girl_rails (~> 4.8)
   faraday-detailed_logger (~> 2.1)

--- a/app/resources/api/v1/ward_resource.rb
+++ b/app/resources/api/v1/ward_resource.rb
@@ -9,7 +9,9 @@ module Api
       private
 
       def enqueue_after_create_job
-        WardAfterCreateJob.perform_later(@model)
+        ActiveRecord::Base.after_transaction do
+          WardAfterCreateJob.perform_later(@model)
+        end
       end
 
     end

--- a/app/services/process_ward_operation.rb
+++ b/app/services/process_ward_operation.rb
@@ -8,7 +8,9 @@ class ProcessWardOperation
 
     report.save!
 
-    SendReportJob.perform_later(report)
+    ActiveRecord::Base.after_transaction do
+      SendReportJob.perform_later(report)
+    end
   end
 
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -54,4 +54,24 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with :truncation
+  end
+
+  config.before(:each) do |example|
+    if example.metadata[:cleaning_strategy] == :truncation
+      DatabaseCleaner.strategy = :truncation
+    else
+      DatabaseCleaner.strategy = :transaction
+    end
+
+    ActiveJob::Base.queue_adapter = example.metadata[:job_adapter] || :test
+
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 end

--- a/spec/requests/api/v1/wards_spec.rb
+++ b/spec/requests/api/v1/wards_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "/api/v1/wards" do
 
-  it "creates a ward if it does not exist" do
+  it "creates a ward if it does not exist", cleaning_strategy: :truncation do
     jsonapi_post("/api/v1/wards", {
       params: {
         data: {
@@ -56,6 +56,8 @@ RSpec.describe "/api/v1/wards" do
     })
     expect(wards.count).to eq 1
 
+    expect(WardAfterCreateJob).to have_been_enqueued.with(wards.first)
+
     # Create another with a different callback url
     jsonapi_post("/api/v1/wards", {
       params: {
@@ -81,6 +83,8 @@ RSpec.describe "/api/v1/wards" do
 
     wards = Ward.where(address: "stellar-address")
     expect(wards.count).to eq 2
+
+    expect(WardAfterCreateJob).to have_been_enqueued.with(wards.last)
   end
 
 end

--- a/spec/resources/api/v1/ward_resource_spec.rb
+++ b/spec/resources/api/v1/ward_resource_spec.rb
@@ -11,21 +11,6 @@ module Api
       it { is_expected.to have_attribute(:callback_url) }
       it { is_expected.to have_attribute(:secret) }
 
-      describe "after_create" do
-        let(:ward) { create(:ward) }
-        let(:resource) { described_class.new(ward, {}) }
-
-        it "enqueues WardAfterCreateJob" do
-          # Don't know how to save a resource manually. Ugly hack it by
-          # 1) ensuring the callback is there
-          # 2) call the callback (`send`) and check that the Job was queued
-          expect(resource._create_callbacks.map(&:filter)).
-            to include(:enqueue_after_create_job)
-          resource.send(:enqueue_after_create_job)
-          expect(WardAfterCreateJob).to have_been_enqueued.with(ward)
-        end
-      end
-
     end
   end
 end

--- a/spec/services/process_ward_operation_spec.rb
+++ b/spec/services/process_ward_operation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ProcessWardOperation do
+RSpec.describe ProcessWardOperation, cleaning_strategy: :truncation do
 
   let(:ward) { create(:ward) }
   let(:operation) { create(:operation) }


### PR DESCRIPTION
There were instances when wards were picked up by the jobs
but they didn't exist to the point of view of the job.